### PR TITLE
Remove contract compile in Makefile

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,20 +20,12 @@ jobs:
           go-version: ^1.16
       - name: Check out code
         uses: actions/checkout@v2
-      - name: Setup node
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
-      - name: Configure node for CI
-        run: cd solidity && npm ci
-      - name: Precompile Solidity contracts
-        run: cd solidity && npm run typechain
       - name: Build the Althea-L1 binary
         run: make
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    needs: Build
+    needs: build
     steps:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
@@ -43,38 +35,18 @@ jobs:
         uses: actions/checkout@v2
       - name: Install golangci-lint 
         run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-      - name: Setup node
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ job.build.strategy.matrix.node-version }}
-      - name: Configure node for CI
-        run: cd solidity && npm ci
-      - name: Precompile Solidity contracts
-        run: cd solidity && npm run typechain
-      - name: Format solidity contracts for Go
-        run: make contracts-auto
       - name: Run golangci-lint
         run: golangci-lint run -c .golangci.yml --disable-all --timeout=30m && go mod verify
 
   test:
     name: Test
     runs-on: ubuntu-latest
-    needs: Build
+    needs: build
     steps:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
           go-version: ^1.16
       - uses: actions/checkout@v2
-      - name: Setup node
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ job.build.strategy.matrix.node-version }}
-      - name: Configure node for CI
-        run: cd solidity && npm ci
-      - name: Precompile Solidity contracts
-        run: cd solidity && npm run typechain
-      - name: Format solidity contracts for Go
-        run: make contracts-auto
       - name: Test
         run: go test ./... -mod=readonly -timeout 30m -coverprofile=profile.out -covermode=atomic -race


### PR DESCRIPTION
Now that we are checking in the compiled contract definition we no longer need to compile the contract on each make.