### PR TITLE
Fixed deprecated ENV format and updated go in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@
 # $ docker build -t <ImageName> .
 # $ docker run --rm -it -p 46657:46657 -p 46656:46656 -v ~/.althea:/althea/.althea <ImageName> althea init <Moniker>
 # $ docker run --rm -it -p 46657:46657 -p 46656:46656 -v ~/.althea:/althea/.althea <ImageName> althea start
-FROM golang:1.15-alpine AS build-env
+FROM golang:1.19-alpine AS build-env
 
 # Set up dependencies
-ENV PACKAGES curl make git libc-dev bash gcc linux-headers eudev-dev python3
+ENV PACKAGES="curl make git libc-dev bash gcc linux-headers eudev-dev python3"
 
 # Set working directory for the build
 WORKDIR /src
@@ -20,7 +20,7 @@ RUN apk add --no-cache $PACKAGES && \
 # Final image
 FROM alpine:edge
 
-ENV ALTHEA /althea
+ENV ALTHEA="/althea"
 
 # Install ca-certificates
 RUN apk add --update ca-certificates && \


### PR DESCRIPTION
1. Docker has deprecated the ENV KEY VALUE format of setting environment variables to the ENV KEY=VALUE format. Updated it in this PR.
2. The go.mod file specifies golang version 1.19, however this Dockerfile was still using 1.15. This was causing issues due to to changes that go made in 1.19 in how it handles GOROOT: https://go-review.googlesource.com/c/go/+/53370

I was not able to successfully build the docker container until I made these changes.