### PR TITLE
Set up file protection on GitHub via CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,23 @@
+# Protect the /.github/ folder from modifications - including the CODEOWNERS file
+/.github @jkilpatr @ChristianBorst
+
+# Protect the Makefile in the root dir
+/Makefile @jkilpatr @ChristianBorst
+
+# Protect all the compilation scripts
+/scripts/ @jkilpatr @ChristianBorst
+
+# Protect the contracts used by the chain
+/contracts/ @jkilpatr @ChristianBorst
+
+# Protect the contract definitions
+/solidity @jkilpatr @ChristianBorst
+/solidity-dex @jkilpatr @ChristianBorst
+
+# Protect all compiled protobuf files
+*.pb.go @jkilpatr @ChristianBorst
+*.pb.gw.go @jkilpatr @ChristianBorst
+
+# Protect the go.mod + go.sum files
+/go.mod @jkilpatr @ChristianBorst
+/go.sum @jkilpatr @ChristianBorst


### PR DESCRIPTION
**To complete the protection the repository settings must be modified by @jkilpatr  using the following instructions**:

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-and-branch-protection

The rules work like so: `<file-matcher> <owner 1> <owner 2> ...`.
The <file-matcher> can be a directory or a wildcard pattern (and even more complicated matching, see the link above) and <owner N> can be a username, contributor email address, or a group like @developers (if there were such a group).