### PR TITLE
Upgrade test improvements

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -210,5 +210,5 @@ jobs:
         with:
           workspaces: integration_tests/
           cache-on-failure: true
-      - name: Tests the Tethys upgrade
-        run: tests/run-upgrade-test.sh v1.4.0
+      - name: Tests the EXAMPLE upgrade
+        run: tests/run-upgrade-test.sh v1.5.1

--- a/app/upgrades/example/README.md
+++ b/app/upgrades/example/README.md
@@ -1,0 +1,8 @@
+# Example Upgrade
+
+The *Example* upgrade contains the following changes.
+
+## Summary of Changes
+
+* First bullet point here
+* Second bullet point here

--- a/app/upgrades/example/handler.go
+++ b/app/upgrades/example/handler.go
@@ -1,0 +1,33 @@
+package example
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	crisiskeeper "github.com/cosmos/cosmos-sdk/x/crisis/keeper"
+	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+)
+
+var PlanName = "example"
+
+func GetExampleUpgradeHandler(
+	mm *module.Manager, configurator *module.Configurator, crisisKeeper *crisiskeeper.Keeper, distrKeeper *distrkeeper.Keeper,
+) func(
+	ctx sdk.Context, plan upgradetypes.Plan, vmap module.VersionMap,
+) (module.VersionMap, error) {
+	if mm == nil {
+		panic("Nil argument to GetExampleUpgradeHandler")
+	}
+	return func(ctx sdk.Context, plan upgradetypes.Plan, vmap module.VersionMap) (module.VersionMap, error) {
+		ctx.Logger().Info("Module Consensus Version Map", "vmap", vmap)
+
+		ctx.Logger().Info("Example Upgrade: Running any configured module migrations")
+		out, outErr := mm.RunMigrations(ctx, *configurator, vmap)
+
+		ctx.Logger().Info("Asserting invariants after upgrade")
+		crisisKeeper.AssertInvariants(ctx)
+
+		ctx.Logger().Info("Example Upgrade Successful")
+		return out, outErr
+	}
+}

--- a/app/upgrades/register.go
+++ b/app/upgrades/register.go
@@ -6,6 +6,7 @@ import (
 	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
 	upgradekeeper "github.com/cosmos/cosmos-sdk/x/upgrade/keeper"
 
+	"github.com/AltheaFoundation/althea-L1/app/upgrades/example"
 	"github.com/AltheaFoundation/althea-L1/app/upgrades/tethys"
 )
 
@@ -24,5 +25,10 @@ func RegisterUpgradeHandlers(
 	upgradeKeeper.SetUpgradeHandler(
 		tethys.PlanName,
 		tethys.GetTethysUpgradeHandler(mm, configurator, crisisKeeper, distrKeeper),
+	)
+	// EXAMPLE upgrade
+	upgradeKeeper.SetUpgradeHandler(
+		example.PlanName,
+		example.GetExampleUpgradeHandler(mm, configurator, crisisKeeper, distrKeeper),
 	)
 }

--- a/integration_tests/test_runner/src/tests/upgrade.rs
+++ b/integration_tests/test_runner/src/tests/upgrade.rs
@@ -1,9 +1,6 @@
 use crate::utils::{
     execute_upgrade_proposal, wait_for_block, UpgradeProposalParams, ValidatorKeys, EVM_USER_KEYS,
 };
-use althea_proto::cosmos_sdk_proto::cosmos::distribution::v1beta1::{
-    query_client::QueryClient as DistributionQueryClient, QueryParamsRequest,
-};
 use clarity::Address as EthAddress;
 use deep_space::client::ChainStatus;
 use deep_space::{Contact, CosmosPrivateKey};
@@ -16,7 +13,7 @@ use super::microtx_fees::microtx_fees_test;
 use super::native_token::native_token_test;
 
 pub const UPGRADE_NAME: &str = "example";
-const UPGRADE_BLOCK_DELTA: u64 = 20;
+const UPGRADE_BLOCK_DELTA: u64 = 30;
 
 /// Perform a series of integration tests to seed the system with data, then submit and pass a chain
 /// upgrade proposal


### PR DESCRIPTION
* Add bootstrapping failure handling (JSONRPC server is down while the UPGRADE_PART_2 is running)
* Decrease upgrade test block delta from 40 to 30 to improve the test speed (failure with delta = 20)